### PR TITLE
рефакторинг: расширяем контракт и ускоряем /all_profiles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest
+        pytest -o log_cli=true

--- a/cd2b_api.py
+++ b/cd2b_api.py
@@ -81,6 +81,9 @@ class Profile:
 
         git.Repo.clone_from(self.github, repo_path)
 
+    async def has_properties(self):
+        return os.path.exists(self.__property_file_path())
+
     # build docker container with name self.docker_image_name
     async def build(self, websocket: Optional['WebSocket'] = None):
         await self.remove_image()
@@ -262,8 +265,9 @@ async def get_all_profiles() -> list[Profile]:
                 {
                     'name': dict_profile[1],
                     'github': dict_profile[2],
-                    'port': dict_profile[3]
-                }
+                    'port': dict_profile[3],
+                },
+                post_proc=False
             )
         )
     return result

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ class ProfileRequest(BaseModel):
     post_proc: Optional['bool'] = None
 
 
+# Контракт на профиль
 async def profile_response(profile: cd2b_api.Profile):
     return {
         "name": await profile.name,
@@ -24,6 +25,7 @@ async def profile_response(profile: cd2b_api.Profile):
         "repo_uri": profile.github,
         "port": profile.port,
         "image_name": profile.docker_image_name,
+        "has_properties": await profile.has_properties(),
         "is_running": await profile.is_running()
     }
 
@@ -195,7 +197,6 @@ async def rerun_post(profile_name: str, external_port: int = -1, rebuild: bool =
         rebuild=rebuild
     )
     return await profile_response(profile)
-
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/test_main.py
+++ b/test_main.py
@@ -52,7 +52,16 @@ def test_create_profile():
         "/create_profile",
         json=json_data
     )
+
+    profile_info = response.json()['profile']
     assert response.status_code == 200
+    assert profile_info['name'] == 'test_profile'
+    assert profile_info['repo_name'] == 'snomephi_bot'
+    assert profile_info['repo_uri'] == 'https://github.com/sno-mephi/snomephi_bot.git'
+    assert profile_info['port'] == 9913
+    assert profile_info['image_name'] == 'cd2b_snomephi_bot_test_profile'
+    assert profile_info['has_properties'] == False
+    assert profile_info['is_running'] == False
 
 
 def test_check_profile():
@@ -70,6 +79,7 @@ def test_check_profile():
     assert profile_info['repo_uri'] == 'https://github.com/sno-mephi/snomephi_bot.git'
     assert profile_info['port'] == 9913
     assert profile_info['image_name'] == 'cd2b_snomephi_bot_test_profile'
+    assert profile_info['has_properties'] == False
     assert profile_info['is_running'] == False
 
 
@@ -88,6 +98,15 @@ def test_upload_properties():
     )
     assert response.status_code == 200
     assert os.path.exists(excepted_path)
+
+    profile_info = response.json()
+    assert profile_info['name'] == 'test_profile'
+    assert profile_info['repo_name'] == 'snomephi_bot'
+    assert profile_info['repo_uri'] == 'https://github.com/sno-mephi/snomephi_bot.git'
+    assert profile_info['port'] == 9913
+    assert profile_info['image_name'] == 'cd2b_snomephi_bot_test_profile'
+    assert profile_info['has_properties'] == True
+    assert profile_info['is_running'] == False
 
 
 def test_set_port():
@@ -113,6 +132,16 @@ def test_all_profiles():
 
     assert response.status_code == 200
     assert len(response.json()) == 1
+
+    profile_info = response.json()[0]
+
+    assert profile_info['name'] == 'test_profile'
+    assert profile_info['repo_name'] == 'snomephi_bot'
+    assert profile_info['repo_uri'] == 'https://github.com/sno-mephi/snomephi_bot.git'
+    assert profile_info['port'] == 7779
+    assert profile_info['image_name'] == 'cd2b_snomephi_bot_test_profile'
+    assert profile_info['has_properties'] == True
+    assert profile_info['is_running'] == False
 
 
 def test_bandr_post():


### PR DESCRIPTION
- `/all_profiles` ускорена за счет отлючения пост-процесса при получении профиля (ненужное действие, так как профили при создании проходят процесс пост-процессинга
- расширяем контракт для профилей: добавлено поле 'has_properties', которое говорит, был ли загружен файл `application.properties` для профиля или нет
- в workflow теперь вместо `pytest` запускается `pytest -o log_cli=true`, что позволяет сразу видеть логи. Логи, кстати, надо настроить
- более широкое покрытие тестами